### PR TITLE
feat: priority sema implemented

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -145,4 +145,21 @@ int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
 
+/* functions added for 1) alarm clock */
+bool compare_tick(const struct list_elem *a,
+                  const struct list_elem *b,
+                  void *aux);
+void thread_sleep(int64_t ticks);
+void set_global_ticks();
+int64_t get_global_ticks();
+void thread_wakeup(int64_t nowtime);
+
+/* functions added for 2) priority */
+bool compare_priority(const struct list_elem *a,
+					const struct list_elem *b,
+					void *aux);
+/* ready list의 첫 번째 스레드와 현재 실행중인 스레드를 비교한다.
+	더 높은 우선순위의 스레드에게 yield한다. */
+void thread_preempt();
+
 #endif /* threads/thread.h */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -497,11 +497,6 @@ thread_set_priority (int new_priority) {
 	
 	list_sort(&ready_list, compare_priority, NULL);		// 다시 ready list를 정렬한다. 
 	thread_preempt();	// 선점 여부를 확인한다.
-	/* 현재 스레드의 새로운 우선순위와 ready list의 첫 요소 (가장 우선순위가 높은) 비교한다.
-		현재 스레드의 우선순위가 더 낮다면, CPU를 yield한다. */
-	// if (thread_current()->priority < list_entry(list_begin(&ready_list), struct thread, elem)) {
-	// 	thread_yield();
-	// }
 }
 
 /* Returns the current thread's priority. */


### PR DESCRIPTION
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
FAIL tests/threads/priority-donate-one
FAIL tests/threads/priority-donate-multiple
FAIL tests/threads/priority-donate-multiple2
FAIL tests/threads/priority-donate-nest
FAIL tests/threads/priority-donate-sema
FAIL tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
FAIL tests/threads/priority-condvar
FAIL tests/threads/priority-donate-chain
FAIL tests/threads/mlfqs/mlfqs-load-1
FAIL tests/threads/mlfqs/mlfqs-load-60
FAIL tests/threads/mlfqs/mlfqs-load-avg
FAIL tests/threads/mlfqs/mlfqs-recent-1
FAIL tests/threads/mlfqs/mlfqs-fair-2
FAIL tests/threads/mlfqs/mlfqs-fair-20
FAIL tests/threads/mlfqs/mlfqs-nice-2
FAIL tests/threads/mlfqs/mlfqs-nice-10
FAIL tests/threads/mlfqs/mlfqs-block
17 of 27 tests failed.