### PR TITLE
feat: priority condvar implemented

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "type": "gdb",
+      "request": "attach",
+      "name": "Attach to gdbserver : threads",
+      "executable": "${workspaceRoot}/threads/build/kernel.o",
+      "target": "localhost:1234",
+      "remote": true,
+      "cwd": "${workspaceRoot}",
+      "valuesFormatting": "parseText"
+    }
+  ]
+}

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -33,8 +33,8 @@
 #include "threads/thread.h"
 
 /* sema->waiters()*/
-bool compare_sema_priority(const struct list_elem *a,
-							const struct list_elem *b,
+bool compare_sema_priority(const struct list_elem *selem_a,
+							const struct list_elem *selem_b,
 							void *aux);
 
 /* Initializes semaphore SEMA to VALUE.  A semaphore is a
@@ -71,7 +71,8 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {		// 0일 동안, 즉 다른 스레드가 lock을 가지고 있는 동안
-		list_push_back (&sema->waiters, &thread_current ()->elem);	// init된 sema->waiter 안에 실제로 스레드가 포함된다.
+		/* list_insert_ordered를 사용하지 않아도 되는 이유? */
+		list_push_back (&sema->waiters, &thread_current ()->elem);	// init된 sema->waiter 안에 실제로 스레드가 포함된다.	
 		thread_block ();			// 현재 스레드는 블락 상태이다.
 	}
 	sema->value--;
@@ -118,6 +119,12 @@ sema_up (struct semaphore *sema) {
 		/* cond의 waiter에 붙어 오는 sema의 경우, 
 			sema->waiters에는 항상 1개의 스레드만 존재한다.
 			그러나, cond를 사용하지 않는 경우 여러 스레드가 sema->waiters에 기다릴 수 있기 때문에 sort 해준다. */
+
+		/* compare_priority를 그대로 사용하는 이유? 
+			sema_down에서 list에 push될 때, 
+			thread::elem이 그대로 넘어온다.
+			즉, semaphore_elem::elem이 아니므로 (cond의 경우)
+			기존의 우선순위 비교 함수를 그대로 사용할 수 있다. */
 		list_sort(&sema->waiters, compare_priority, NULL);
 		thread_unblock (list_entry (list_pop_front (&sema->waiters),	
 					struct thread, elem));		// 새로운 스레드가 ready list에 추가된다.
@@ -293,7 +300,19 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+
+	/* cond->waiters list에 semaphore 구조체를 넣어준다. 
+		실제로 락을 기다리는 것은 스레드인데, 왜 세마포어를 넣어줄까?
+		semaphore 안에 value와 waiters가 존재하기 때문이다. 
+		- value를 통해 semaphore를 제어할 수 있고,
+		- semaphore->waiters 안에는 1개의 스레드만 존재하게 된다. */
+
+	/* cond_signal에서 pop하기 전에 정렬을 하면 push_back으로도 동작한다. */
+	// list_push_back (&cond->waiters, &waiter.elem);
+
+	/* semaphore_elem::elem의 형태로 cond->waiters list에 추가된다.
+		따라서, 이렇게 랩핑된 요소를 추출해 비교하는 새로운 함수가 필요하다.*/
+	list_insert_ordered(&cond->waiters, &waiter.elem, compare_sema_priority, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);
@@ -313,9 +332,11 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
+	if (!list_empty (&cond->waiters)) {
+		list_sort(&cond->waiters, compare_sema_priority, NULL);
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by
@@ -331,4 +352,21 @@ cond_broadcast (struct condition *cond, struct lock *lock) {
 
 	while (!list_empty (&cond->waiters))
 		cond_signal (cond, lock);
+}
+
+/* semaphore_elem::elem인 list_elem에서 priority를 비교하는 함수 */
+bool compare_sema_priority(const struct list_elem *a,
+							const struct list_elem *b,
+							void *aux) {
+	const struct semaphore_elem *selem_a = list_entry(a, struct semaphore_elem, elem);
+	const struct semaphore_elem *selem_b = list_entry(b, struct semaphore_elem, elem);
+
+	const struct list waiters_a = selem_a->semaphore.waiters;
+	const struct list waiters_b = selem_b->semaphore.waiters;
+
+	/* waiters 안에는 1개의 스레드만 있다. */
+	const struct thread *thread_a = list_entry(list_begin(&waiters_a), struct thread, elem);
+	const struct thread *thread_b = list_entry(list_begin(&waiters_b), struct thread, elem);
+	
+	return thread_a->priority > thread_b->priority;
 }


### PR DESCRIPTION
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
FAIL tests/threads/priority-donate-one
FAIL tests/threads/priority-donate-multiple
FAIL tests/threads/priority-donate-multiple2
FAIL tests/threads/priority-donate-nest
FAIL tests/threads/priority-donate-sema
FAIL tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
FAIL tests/threads/priority-donate-chain
FAIL tests/threads/mlfqs/mlfqs-load-1
FAIL tests/threads/mlfqs/mlfqs-load-60
FAIL tests/threads/mlfqs/mlfqs-load-avg
FAIL tests/threads/mlfqs/mlfqs-recent-1
FAIL tests/threads/mlfqs/mlfqs-fair-2
FAIL tests/threads/mlfqs/mlfqs-fair-20
FAIL tests/threads/mlfqs/mlfqs-nice-2
FAIL tests/threads/mlfqs/mlfqs-nice-10
FAIL tests/threads/mlfqs/mlfqs-block
16 of 27 tests failed.