### PR TITLE
feat: donation implemented

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -495,7 +495,8 @@ void
 thread_set_priority (int new_priority) {
 	/* priority가 아예 바뀌었으므로 original priority를 갱신한다. */
 	thread_current ()->original_priority = new_priority;		// 새로운 우선순위 설정
-
+	thread_current()->priority = new_priority;
+	
 	/* 현재 스레드의 우선순위가 더 낮아진 경우,
 		다시 donations list를 확인하며 현재 스레드의 우선순위를 갱신한다. */
 	update_donation();


### PR DESCRIPTION
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/threads/mlfqs/mlfqs-load-1
FAIL tests/threads/mlfqs/mlfqs-load-60
FAIL tests/threads/mlfqs/mlfqs-load-avg
FAIL tests/threads/mlfqs/mlfqs-recent-1
FAIL tests/threads/mlfqs/mlfqs-fair-2
FAIL tests/threads/mlfqs/mlfqs-fair-20
FAIL tests/threads/mlfqs/mlfqs-nice-2
FAIL tests/threads/mlfqs/mlfqs-nice-10
FAIL tests/threads/mlfqs/mlfqs-block
9 of 27 tests failed.